### PR TITLE
Handle SECURE_BOOT VMs when updating (terraform apply)

### DIFF
--- a/nutanix/resource_nutanix_virtual_machine.go
+++ b/nutanix/resource_nutanix_virtual_machine.go
@@ -1337,6 +1337,12 @@ func changePowerState(ctx context.Context, conn *v3.Client, id string, powerStat
 	spec.AvailabilityZoneReference = response.Status.AvailabilityZoneReference
 	spec.ClusterReference = response.Status.ClusterReference
 
+	// check if SECURE_BOOT is set, we need to set MachineType to Q35 if that's the case.
+	if *res.BootConfig.BootType == "SECURE_BOOT" {
+		log.Printf("[DEBUG] Machine Boot is set to Secure Boot, set MachineType to Q35")
+		res.MachineType = response.Spec.Resources.MachineType
+	}
+
 	res.PowerStateMechanism = pw
 	spec.Resources = res
 	request.Metadata = metadata

--- a/nutanix/resource_nutanix_virtual_machine.go
+++ b/nutanix/resource_nutanix_virtual_machine.go
@@ -1203,6 +1203,12 @@ func resourceNutanixVirtualMachineUpdate(ctx context.Context, d *schema.Resource
 		metadata.SpecVersion = specVersion
 	}
 
+	// Check if we are dealing with SECURE_BOOT machine, MachineType is needed then set to Q35
+	if *res.BootConfig.BootType == "SECURE_BOOT" {
+		log.Printf("[DEBUG] UpdateVM: Machine Boot is set to Secure Boot, set MachineType to Q35")
+		res.MachineType = response.Spec.Resources.MachineType
+	}
+
 	spec.Resources = res
 	request.Metadata = metadata
 	request.Spec = spec


### PR DESCRIPTION
When you have SECURE_BOOT VMs, you also need to specify Machine Type as Q35, otherwise Nutanix REST API is denying power off operation and the update operation itself.

Not sure if you can change SECURE_BOOT created VMs to Legacy Boot or UEFI Boot, not tested those cases